### PR TITLE
raft: separate MaxCommittedSizePerReady config from MaxSizePerMsg

### DIFF
--- a/raft/node_test.go
+++ b/raft/node_test.go
@@ -894,7 +894,7 @@ func TestAppendPagination(t *testing.T) {
 func TestCommitPagination(t *testing.T) {
 	s := NewMemoryStorage()
 	cfg := newTestConfig(1, []uint64{1}, 10, 1, s)
-	cfg.MaxSizePerMsg = 2048
+	cfg.MaxCommittedSizePerReady = 2048
 	r := newRaft(cfg)
 	n := newNode()
 	go n.run(r)


### PR DESCRIPTION
Please read https://github.com/etcd-io/etcd/blob/master/CONTRIBUTING.md#contribution-flow.
